### PR TITLE
Fix MinGW build / sprintf_s error

### DIFF
--- a/src/yajl_tree.c
+++ b/src/yajl_tree.c
@@ -25,7 +25,7 @@
 
 #include "yajl_parser.h"
 
-#if defined(_WIN32) || defined(WIN32)
+#if ( (defined(_WIN32) || defined(WIN32)   ) && (  defined(_MSC_VER)  ) )
 #define snprintf sprintf_s
 #endif
 


### PR DESCRIPTION
I'm trying to build the MCU code on Windows with MinGW and came across this/
Fixes this issue: https://github.com/lloyd/yajl/issues/167

I though I make a PR here instead of upstream since there hasn't been any update in upstream since March 2014.
